### PR TITLE
Upgrade Python Connector bump python version

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ The plugin can be installed from the plugin page in Dataiku DSS:
 ![add_plugin_from_git_repo](resources/add_plugin_from_git_repo.png)
 
 Next step is to create a code environment for the plugin (which installs needed dependencies:
-                                                          kdp-python-connector, kdp-api-python-client)
+                                                          kdp-python-connector with included kdp-api-python-client)
 ![add_code_environment](resources/add_code_environment.png)
 
 

--- a/code-env/python/desc.json
+++ b/code-env/python/desc.json
@@ -1,5 +1,5 @@
 {
-  "acceptedPythonInterpreters": ["PYTHON37"],
+  "acceptedPythonInterpreters": ["PYTHON37", "PYTHON38"],
   "forceConda": false,
   "installCorePackages": true,
   "installJupyterSupport": false

--- a/code-env/python/spec/requirements.txt
+++ b/code-env/python/spec/requirements.txt
@@ -1,2 +1,1 @@
-kdp-api-python-client==0.19.0
-kdp-python-connector==0.18.0
+kdp-python-connector==0.30.0


### PR DESCRIPTION
Upgrade Python Connector to latest version, allow Python38 

## why does this matter?
- Brings the python connector up to date for dataiku use.

## what was impacted?
- Version bump for python connector, allowing use of python 3.8 with dataiku.

## how do you know this works?
- Verified in dataiku data science studio with our plugin

## how does this make you feel?
👐 